### PR TITLE
Fixed nginx root user issue

### DIFF
--- a/sample-applications/document-summarization/docker-compose.yaml
+++ b/sample-applications/document-summarization/docker-compose.yaml
@@ -1,12 +1,12 @@
 services:
   nginx:
-    image: nginx:latest
+    image: nginxinc/nginx-unprivileged:1.27.4
     environment:
       - no_proxy=${no_proxy},docsum-ui,docsum-api
       - http_proxy=${http_proxy}
       - https_proxy=${https_proxy}
     ports:
-      - "8101:80"
+      - "8101:8080"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
     depends_on:

--- a/sample-applications/document-summarization/nginx.conf
+++ b/sample-applications/document-summarization/nginx.conf
@@ -1,9 +1,11 @@
+pid /tmp/nginx.pid;
+
 events {}
 
 http {
     server {
-        listen       80;
-        listen  [::]:80;
+        listen       8080;
+        listen  [::]:8080;
 
         client_max_body_size 500M;
         proxy_read_timeout 300;


### PR DESCRIPTION
nginx.conf:

-> listen 8080; - nginx listening on port 8080 internally (non-root safe, bcz port <1024 are privileged ports)
->  pid /tmp/nginx.pid; - non-root compatible PID file location

docker-compose.yaml:

-> image: nginxinc/nginx-unprivileged:1.27.4 - non-root nginx image
-> ports: "8101:8080" - mapping external port 8101 to internal port 8080

Ran CIS report, not seeing "running as root for nginx" error with this change, and app also works fine (along with OTEL)


